### PR TITLE
Support S3_ENDPOINT_URL for non-AWS storage.

### DIFF
--- a/awsio/csrc/io/s3/s3_io.cpp
+++ b/awsio/csrc/io/s3/s3_io.cpp
@@ -85,6 +85,11 @@ Aws::Client::ClientConfiguration &setUpS3Config() {
     } else {
         cfg.region = "us-west-2";
     }
+
+    const char *endpoint_url = getenv("S3_ENDPOINT_URL");
+    if (endpoint_url) {
+        cfg.endpointOverride = endpoint_url;
+    }
     return cfg;
 }
 


### PR DESCRIPTION
Add flag to support endpointOverride configuration, enables connecting
to and using object stores that require this.

As an example of other tools using this pattern see [s5cmd](https://github.com/peak/s5cmd).

Manually tested and validated to work.

*Issue #, if available:*

*Description of changes:* Add command line flag that plumbs into AWS client configuration.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
