### PR TITLE
Support proxy configuration for S3 client

### DIFF
--- a/awsio/csrc/io/s3/s3_io.cpp
+++ b/awsio/csrc/io/s3/s3_io.cpp
@@ -90,6 +90,16 @@ Aws::Client::ClientConfiguration &setUpS3Config() {
     if (endpoint_url) {
         cfg.endpointOverride = endpoint_url;
     }
+
+    const char *proxy_host = getenv("PROXY_HOST");
+    if (proxy_host) {
+        cfg.proxyHost = proxy_host;
+    }
+
+    const char *proxy_port = getenv("PROXY_PORT");
+    if (proxy_port) {
+        cfg.proxyPort = atoi(proxy_port);
+    }
     return cfg;
 }
 

--- a/awsio/csrc/io/s3/s3_io.cpp
+++ b/awsio/csrc/io/s3/s3_io.cpp
@@ -91,12 +91,12 @@ Aws::Client::ClientConfiguration &setUpS3Config() {
         cfg.endpointOverride = endpoint_url;
     }
 
-    const char *proxy_host = getenv("PROXY_HOST");
+    const char *proxy_host = getenv("S3_PROXY_HOST");
     if (proxy_host) {
         cfg.proxyHost = proxy_host;
     }
 
-    const char *proxy_port = getenv("PROXY_PORT");
+    const char *proxy_port = getenv("S3_PROXY_PORT");
     if (proxy_port) {
         cfg.proxyPort = atoi(proxy_port);
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR enables connecting to S3 over proxy by adding flags to support proxyHost & proxyPort configuration for the AWS SDK CPP. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
